### PR TITLE
Feature Sidebar Tweaks

### DIFF
--- a/src/components/AssigneeAvatar.jsx
+++ b/src/components/AssigneeAvatar.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react"
 import { useUser } from "../contexts/UsersContext"
 
-export default function AssigneeAvatar({ assigneeId, displayName, size=24, className = "", debugSource}) {
+export default function AssigneeAvatar({ assigneeId, displayName, size=24, className = "", showName = true}) {
   const { user } = useUser(assigneeId);
   const name = user?.name || displayName || "";
   const initials = useMemo(() => {
@@ -20,7 +20,7 @@ export default function AssigneeAvatar({ assigneeId, displayName, size=24, class
           className={`rounded-full object-cover ${className}`}
           style={{ width: size, height: size }}
         />
-        <span className={`${className}`}>{user.name}</span>
+        {showName && <span className={`${className}`}>{user.name}</span>}
       </>
     )
   }
@@ -34,7 +34,7 @@ export default function AssigneeAvatar({ assigneeId, displayName, size=24, class
       >
         {initials}
       </div>
-      <span className={`${className}`}>{name || "Unassigned"}</span>
+      {showName && <span className={`${className}`}>{name || "Unassigned"}</span>}
     </>
   )
 }

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -2,8 +2,11 @@ import React from "react";
 import { FaCalendarAlt, FaClipboardList, FaUser } from "react-icons/fa";
 import { Link, NavLink } from "react-router-dom";
 import logo from "../assets/logo-with-face-outlined.svg";
+import { useAuth } from "../contexts/AuthContext";
+import AssigneeAvatar from "./AssigneeAvatar";
 
 export default function Navbar() {
+  const { currentUser } = useAuth();
   const navLinkStyles = ({ isActive }) =>
     `flex flex-col items-center justify-center text-xs font-medium ${
       isActive ? "text-white" : "text-rose-200"
@@ -30,8 +33,8 @@ export default function Navbar() {
               className={({ isActive }) =>
                 `flex items-center gap-3 rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
                   isActive
-                    ? "bg-white text-primaryRed"
-                    : "text-white hover:bg-white/10"
+                  ? "bg-white/20 text-white"        // translucent white background, keep text white
+                  : "text-white hover:bg-white/10"
                 }`
               }
             >
@@ -44,8 +47,8 @@ export default function Navbar() {
               className={({ isActive }) =>
                 `flex items-center gap-3 rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
                   isActive
-                    ? "bg-white text-primaryRed"
-                    : "text-white hover:bg-white/10"
+                  ? "bg-white/20 text-white"        // translucent white background, keep text white
+                  : "text-white hover:bg-white/10"
                 }`
               }
             >
@@ -60,15 +63,20 @@ export default function Navbar() {
           <NavLink
             to="/profile"
             className={({ isActive }) =>
-              `flex items-center gap-3 rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
+              `flex items-center justify-between gap-3 rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
                 isActive
-                  ? "bg-white text-primaryRed"
-                  : "text-white hover:bg-white/10"
+                ? "bg-white/20 text-white"        // translucent white background, keep text white
+                : "text-white hover:bg-white/10"
               }`
             }
           >
-            <FaUser size={18} />
-            <span>Profile</span>
+            {/* Left: avatar with initials fallback */}
+            <div className="flex items-center gap-3">
+              {currentUser?.uid && (
+                <AssigneeAvatar assigneeId={currentUser.uid} size={28} showName={false} />
+              )}
+              <span className="text-white md:text-inherit">Profile</span>
+            </div>
           </NavLink>
         </div>
       </nav>
@@ -84,8 +92,9 @@ export default function Navbar() {
           <span>My Items</span>
         </NavLink>
         <NavLink to="/profile" className={navLinkStyles}>
-          <FaUser size={20} />
-          <span>Profile</span>
+            {currentUser?.uid && (
+              <AssigneeAvatar assigneeId={currentUser.uid} size={34} showName={false}/>
+            )}
         </NavLink>
       </nav>
     </>


### PR DESCRIPTION
#Summary
	1.	Added avatars to the Profile link → on both desktop sidebar and mobile bottom nav, we now show the user’s avatar (or initials fallback) next to the “Profile” label.
	2.	Updated AssigneeAvatar → introduced a showName prop so the component can display only the avatar/initials in tight spaces (like Navbar) while still showing the full [Avatar + Name] everywhere else.
#Screenshot/Video
##Desktop
<img width="363" height="176" alt="Screenshot 2025-08-29 at 10 58 50 PM" src="https://github.com/user-attachments/assets/90606782-f8f0-40a6-99e2-32eb712cbc91" />
##Mobile
<img width="515" height="227" alt="Screenshot 2025-08-29 at 10 59 35 PM" src="https://github.com/user-attachments/assets/cfea9fa7-d018-430d-8016-60fb3d4ef5c5" />
