### PR TITLE
EventModal items Bug Fixed

### DIFF
--- a/src/components/EventModal.jsx
+++ b/src/components/EventModal.jsx
@@ -10,7 +10,7 @@ export default function EventModal({ closeModal, onSubmit, initialData = {} }) {
     title: initialData.title || "",
     description: initialData.description || "",
     date: initialData.date || null,
-    items: [],
+    items: initialData.items || [],
     time: initialData.time || "",
     location: initialData.location || "",
     createdBy: initialData.createdBy || currentUser.name,
@@ -86,7 +86,7 @@ export default function EventModal({ closeModal, onSubmit, initialData = {} }) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
       <div
-        className="relative ml-0 w-full max-w-md overflow-y-auto rounded-2xl bg-yellow-50 p-4 shadow-lg ml-8 mr-8 md:ml-[236px]"
+        className="relative ml-0 ml-8 mr-8 w-full max-w-md overflow-y-auto rounded-2xl bg-yellow-50 p-4 shadow-lg md:ml-[236px]"
         style={{ maxHeight: modalHeight }}
       >
         <div className="flex justify-center">


### PR DESCRIPTION
If an event had items and the event was edited, it would re-initiate the event with an empty array and delete all of its items. Line 13 in EventModal needed to take in the initialData.
<img width="1328" height="375" alt="image" src="https://github.com/user-attachments/assets/c24b1edf-67c7-4cef-9868-13e297c6fa35" />
